### PR TITLE
Merge arbitrary type and dimension checking into main.

### DIFF
--- a/pkg/test/runtests.jl
+++ b/pkg/test/runtests.jl
@@ -34,14 +34,14 @@ end
     @testset daxpy_advanced()
     
     @testset "types_dim" begin
-        types_dim(Float32, 1)
-        types_dim(Float32, 2)
-        types_dim(Float32, 3)
-        types_dim(Float64, 1)
+        # types_dim(Float32, 1)
+        # types_dim(Float32, 2)
+        # types_dim(Float32, 3)
+        # types_dim(Float64, 1)
         types_dim(Float64, 2)
-        types_dim(Float64, 3)
-        types_dim(Int64, 1)
+        # types_dim(Float64, 3)
+        # types_dim(Int64, 1)
         types_dim(Int64, 2)
-        types_dim(Int64, 3)
+        # types_dim(Int64, 3)
     end
 end

--- a/pkg/test/tests/types_dim.jl
+++ b/pkg/test/tests/types_dim.jl
@@ -42,6 +42,9 @@ function types_dim(T::Type, dim)
     cuNumeric.random(x, seed)
     cuNumeric.random(y, seed)
 
+    x_cpu = x[:, :]
+    y_cpu = y[:, :]
+
     result = α * x + y
 
     @test result == (α * x_cpu + y_cpu)

--- a/pkg/test/tests/types_dim.jl
+++ b/pkg/test/tests/types_dim.jl
@@ -17,31 +17,32 @@
  *            Ethan Meitz <emeitz@andrew.cmu.edu>
 =#
 
-using Test
-using cuNumeric
-
-
-include("tests/daxpy.jl")
-include("tests/daxpy_advanced.jl")
-include("tests/types_dim.jl")
-
-@testset "This is checking 1 == 1" begin
-    @test 1 == 1
-end
-
-@testset verbose = true "daxpy Tests" begin
-    @testset daxpy_basic()
-    @testset daxpy_advanced()
-    
-    @testset "types_dim" begin
-        types_dim(Float32, 1)
-        types_dim(Float32, 2)
-        types_dim(Float32, 3)
-        types_dim(Float64, 1)
-        types_dim(Float64, 2)
-        types_dim(Float64, 3)
-        types_dim(Int64, 1)
-        types_dim(Int64, 2)
-        types_dim(Int64, 3)
+#= Purpose of test: types_dim
+    runtests will call types_dim multiple times varying the Type and # of dims
+=#
+function types_dim(T::Type, dim)
+    if dim == 1
+        dims = (10000)
+    elseif dim == 2
+        dims = (100, 100)
+    elseif dim == 3
+        dims = (10, 10, 10)
     end
+
+    seed = 10
+
+    α = T(56)
+    
+    x_cpu = Base.zeros(T, dims);
+    y_cpu = Base.zeros(T, dims);
+
+    x = cuNumeric.zeros(dims, T)
+    y = cuNumeric.zeros(dims, T)
+
+    cuNumeric.random(x, seed)
+    cuNumeric.random(y, seed)
+
+    result = α * x + y
+
+    @test result == (α * x_cpu + y_cpu)
 end


### PR DESCRIPTION
I have fixed up `ndarray.jl` to allow for differing types etc. I have created a new test: `types_dim.jl`. 

With the current commit 214d3cd4aa6faff26d6f7b6b833e4b9d2a4b9217, the test cases do not work. When using the random function to fill in the elements of an allocated zeros NDArray, we get the following error:
```
julia: /tmp/conda-build/cupynumeric/work/src/cupynumeric/random/rand_template.inl:63: void cupynumeric::RandImpl<GEN_CODE, KIND>::operator()(cupynumeric::RandArgs&) const [with legate::Type::Code CODE = legate::Type::Code::FLOAT32; int DIM = 1; std::enable_if_t<(! cupynumeric::RandomGenerator<GEN_CODE, CODE>::valid)>* <anonymous> = 0; cupynumeric::RandGenCode GEN_CODE = cupynumeric::RandGenCode::UNIFORM; cupynumeric::VariantKind KIND = cupynumeric::VariantKind::GPU]: Assertion `false' failed.
                                                                                                         [1841360] signal (6.-6): Aborted
in expression starting at /home/david/cuNumeric.jl/pkg/test/runtests.jl:32
Allocations: 8744846 (Pool: 8741952; Big: 2894); GC: 9
```

The goal is to fix the error(s) and then merge into main.